### PR TITLE
调整计算方法

### DIFF
--- a/niceratingbar/src/main/java/com/kaelli/niceratingbar/NiceRatingBar.java
+++ b/niceratingbar/src/main/java/com/kaelli/niceratingbar/NiceRatingBar.java
@@ -134,7 +134,7 @@ public class NiceRatingBar extends LinearLayout {
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         if (mRatingStatus == RatingStatus.Enable && !mBoundaryList.isEmpty()) {
-            setRating(calculateRating(event.getRawX()));
+            setRating(calculateRating(event.getX()));
             if (event.getAction() == MotionEvent.ACTION_DOWN) return true;
         }
         return super.onTouchEvent(event);
@@ -145,7 +145,7 @@ public class NiceRatingBar extends LinearLayout {
         super.onLayout(changed, l, t, r, b);
         if (mBoundaryList.isEmpty()) {
             for (int index = 0; index < mStarTotal; index++) {
-                mBoundaryList.add(index == 0 ? getLeft() : mBoundaryList.get(index - 1) + Math.round(mStarWidth) + Math.round(mStarPadding));
+                mBoundaryList.add(index == 0 ? 0 : mBoundaryList.get(index - 1) + Math.round(mStarWidth) + Math.round(mStarPadding));
             }
         }
     }


### PR DESCRIPTION
修复issues #1问题


如果RatingBar外面套一层view则可能计算不准确，例如

`   
 <LinearLayout
        android:layout_width="wrap_content"
        android:layout_height="wrap_content"
        android:layout_gravity="center_horizontal">
        <com.kaelli.niceratingbar.NiceRatingBar
            android:id="@+id/niceRatingBar2"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
            android:layout_gravity="center"
            app:nrb_rating="4.7"
            app:nrb_ratingStatus="Enable"
            app:nrb_starEmptyResource="@drawable/ic_star_border_black_16dp"
            app:nrb_starFullResource="@drawable/ic_star_black_16dp"
            app:nrb_starHalfResource="@drawable/ic_star_half_black_16dp"
            app:nrb_starImageHeight="24dp"
            app:nrb_starImagePadding="4dp"
            app:nrb_starImageWidth="24dp"
            app:nrb_starTotal="5" />
    </LinearLayout>

`